### PR TITLE
Se cambia la direccion del virtual environment a env/ para que se pue…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,5 @@
         "**/*.pyc": true,
         "**/env": true
     },
-    "python.pythonPath": "venv/bin/python",
+    "python.pythonPath": "env/bin/python",
 }


### PR DESCRIPTION
…de usar test.sh 

Antes estaba nombrado como venv/ y por lo tanto no funcionaba el script test.sh